### PR TITLE
Fix migration script by an ugly hack and improve test

### DIFF
--- a/migrations/convert_cache_to_dataclass_v1.py
+++ b/migrations/convert_cache_to_dataclass_v1.py
@@ -9,17 +9,19 @@ Migration:
 """
 import argparse
 import logging
+import os
 import pickle
 import shutil
 import sys
-from dataclasses import dataclass, field
+from importlib.machinery import SourceFileLoader
 
-
-@dataclass
-class CachedData:
-    """CachedData represents locally cached data and state."""
-
-    items: dict = field(default_factory=dict)
+# NOTICE: An ugly hack in order to be able to import CachedData class from
+# rss2irc. I'm real sorry about this, son.
+# NOTE: Sadly, importlib.util and spec didn't cut it. Also, I'm out of time on
+# this. Therefore, see you again in the future once this ceases to work.
+SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
+rss2irc_module_path = os.path.join(SCRIPT_PATH, '..', 'rss2irc.py')
+rss2irc = SourceFileLoader('rss2irc', rss2irc_module_path).load_module()
 
 
 def main():
@@ -48,7 +50,7 @@ def main():
     logger.info("Create backup file '%s' from '%s'.", bak_file, args.cache)
     shutil.copy2(args.cache, bak_file)
 
-    new_cache = CachedData()
+    new_cache = rss2irc.CachedData()
     for key, value in cache.items():
         new_cache.items[key] = value
 

--- a/migrations/tests/files/read_migrated_cache.py
+++ b/migrations/tests/files/read_migrated_cache.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Read migrated cache file."""
+import argparse
+import logging
+import sys
+
+import rss2irc
+
+
+def main():
+    """Try to read given cache file."""
+    args = parse_args()
+    logger = logging.getLogger('read-migrated-cache')
+    cache = rss2irc.read_cache(logger, args.cache)
+    assert isinstance(cache, rss2irc.CachedData)
+    assert len(cache.items)
+    sys.exit(0)
+
+
+def parse_args() -> argparse.Namespace:
+    """Return parsed CLI args."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--cache',
+        dest='cache', type=str, default=None,
+        help='File which contains cache.'
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    main()

--- a/migrations/tests/test_convert_cache_to_dataclass_v1.py
+++ b/migrations/tests/test_convert_cache_to_dataclass_v1.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Unit tests for convert_cache_to_dataclass_v1.py."""
-import io
+import logging
 import os
 import pickle
-import sys
+import subprocess
 import tempfile
-from unittest.mock import patch
 
 import pytest
 
-import migrations.convert_cache_to_dataclass_v1 as migration  # noqa:I202
+import rss2irc  # noqa:I202
+
+SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.fixture
@@ -25,7 +26,10 @@ def fixture_bak_cleanup():
 
     for bak_fname in bak_fnames:
         print("teardown of '{}'".format(bak_fname))
-        os.remove(bak_fname)
+        try:
+            os.unlink(bak_fname)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture
@@ -45,12 +49,6 @@ def test_migration(fixture_cache_file, fixture_bak_cleanup):
     """Test migration under ideal conditions."""
     bak_file = '{}.bak'.format(fixture_cache_file)
     _ = fixture_bak_cleanup(bak_file)
-    expected_cache = migration.CachedData(
-        items={
-            'test1': 1234,
-            'test2': 0,
-        }
-    )
 
     test_data = {
         'test1': 1234,
@@ -59,28 +57,47 @@ def test_migration(fixture_cache_file, fixture_bak_cleanup):
     with open(fixture_cache_file, 'wb') as fhandle:
         pickle.dump(test_data, fhandle, pickle.HIGHEST_PROTOCOL)
 
-    exception = None
-    args = [
-        './convert_cache_to_dataclass_v1.py',
+    expected_cache = rss2irc.CachedData(
+        items={
+            'test1': 1234,
+            'test2': 0,
+        }
+    )
+
+    cmd_migrate = [
+        os.path.join(SCRIPT_PATH, '..', 'convert_cache_to_dataclass_v1.py'),
         '--cache',
         fixture_cache_file,
     ]
+    proc_migrate = subprocess.Popen(
+        cmd_migrate, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    out, err = proc_migrate.communicate()
+    print('migrate-cache STDOUT: {}'.format(out))
+    print('migrate-cache STDERR: {}'.format(err))
+    assert proc_migrate.returncode == 0
 
-    saved_stdout = sys.stdout
-    out = io.StringIO()
-    sys.stdout = out
-
-    with patch.object(sys, 'argv', args):
-        try:
-            migration.main()
-        except Exception as exc:
-            exception = exc
-        finally:
-            sys.stdout = saved_stdout
-
-    assert exception is None
     assert os.path.exists(bak_file) is True
 
-    with open(fixture_cache_file, 'rb') as fhandle:
-        migrated_cache = pickle.load(fhandle)
+    cmd_read = [
+        os.path.join(SCRIPT_PATH, 'files', 'read_migrated_cache.py'),
+        '--cache',
+        fixture_cache_file
+    ]
+    proc_read_env = os.environ.copy()
+    # An ugly hack
+    proc_read_env['PYTHONPATH'] = os.path.join(SCRIPT_PATH, '..', '..')
+
+    proc_read = subprocess.Popen(
+        cmd_read, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=proc_read_env
+    )
+    out, err = proc_read.communicate()
+    print('read-migrated-cache STDOUT: {}'.format(out))
+    print('read-migrated-cache STDERR: {}'.format(err))
+    assert 'Traceback' not in err.decode('utf-8')
+    assert proc_read.returncode == 0
+
+    logger = logging.getLogger('pytest')
+    migrated_cache = rss2irc.read_cache(logger, fixture_cache_file)
     assert migrated_cache == expected_cache


### PR DESCRIPTION
Despite good intentions previous version of migration didn't and won't
work. Also, unit test wasn't good enough to catch this issue.

Therefore, I've applied an ugly hack, because I don't know how else to
solve this(no, I'm not going to create `__init__.py` anywhere just because
of this) and written new unit test(there were couple versions at couple
different places as debugging was moving from one place to another)
which of course was failing with Traceback observed "in production".

Issue was a minor one since it could be solved by temporarily importing
rss2irc where needed.