### PR TITLE
Update pytest-localserver to v0.9.0 and sunset MyContentServer

### DIFF
--- a/ci/run-black.sh
+++ b/ci/run-black.sh
@@ -16,8 +16,7 @@ else
     exit 1
 fi
 
-python3 \
-    -m black \
-    ${black_arg} \
-    -l 80 \
-    `find . ! -path '*/\.*' -name '*.py'`
+
+# shellcheck disable=SC2086
+find . ! -path '*/\.*' -name '*.py' -print0 | \
+    xargs -0 -- python3 -m black ${black_arg} -l 80

--- a/ci/run-reorder-python-imports.sh
+++ b/ci/run-reorder-python-imports.sh
@@ -2,4 +2,5 @@
 set -e
 set -u
 
-reorder-python-imports --py311-plus `find . ! -path '*/\.*' -name '*.py'`
+find . ! -path '*/\.*' -name '*.py' -print0 | \
+    xargs -0 -- reorder-python-imports --py311-plus

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,5 +8,5 @@ flake8-import-order
 reorder-python-imports
 # tests
 pytest
-pytest-localserver==0.8.1
+pytest-localserver==0.9.0
 requests-mock==1.12.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,29 +6,6 @@ import tempfile
 import pytest
 import requests_mock
 from pytest_localserver.http import ContentServer
-from werkzeug.wrappers import Request
-
-
-class MyContentServer(ContentServer):
-    """Wrapper around `pytest_localserver.http.ContentServer`.
-
-    It actually stores intercepted requests and data. It's not the best
-    implementation, but it gets job done - for now.
-    """
-
-    def __init__(self, capture_requests=False, *args, **kwargs):
-        """Init."""
-        self.captured_requests = []
-        self.capture_requests = capture_requests
-        super(MyContentServer, self).__init__(*args, **kwargs)
-
-    def __call__(self, environ, start_response):
-        """Intercept HTTP request and store it, if desired."""
-        if self.capture_requests:
-            request = Request(environ)
-            self.captured_requests.append((request.method, request.get_data()))
-
-        return super(MyContentServer, self).__call__(environ, start_response)
 
 
 @pytest.fixture
@@ -47,7 +24,7 @@ def fixture_cache_file():
 @pytest.fixture
 def fixture_http_server():
     """Return instance of HTTP server for testing."""
-    server = MyContentServer()
+    server = ContentServer()
     server.start()
     yield server
 

--- a/tests/test_gh2slack.py
+++ b/tests/test_gh2slack.py
@@ -243,7 +243,7 @@ def test_main_ideal(
         200,
         {"Content-Type": "application/json"},
     )
-    fixture_http_server.capture_requests = True
+    fixture_http_server.store_request_data = True
     expected_slack_requests = [
         {
             "blocks": [
@@ -330,14 +330,14 @@ def test_main_ideal(
     # Note: this is just a shallow check, but it's better than nothing.
     assert len(fixture_http_server.requests) == 2
     # NOTE(zstyblik): this isn't really optimal.
-    req0 = fixture_http_server.captured_requests[0]
-    assert req0[0] == "POST"
-    data = json.loads(req0[1])
+    req0 = fixture_http_server.requests[0]
+    assert req0.method == "POST"
+    data = req0.get_json()
     assert data in expected_slack_requests
 
-    req1 = fixture_http_server.captured_requests[1]
-    assert req1[0] == "POST"
-    data = json.loads(req1[1])
+    req1 = fixture_http_server.requests[1]
+    assert req1.method == "POST"
+    data = req1.get_json()
     assert data in expected_slack_requests
 
 

--- a/tests/test_git_commits2slack.py
+++ b/tests/test_git_commits2slack.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Unit tests for git_commits2slack.py."""
 import io
-import json
 import os
 import subprocess
 import sys
@@ -311,7 +310,7 @@ def test_main_ideal(
         200,
         {"Content-Type": "application/json"},
     )
-    fixture_http_server.capture_requests = True
+    fixture_http_server.store_request_data = True
     expected_slack_requests = [
         {
             "blocks": [
@@ -384,7 +383,7 @@ def test_main_ideal(
     # Note: this is just a shallow check, but it's better than nothing.
     assert len(fixture_http_server.requests) == 1
 
-    req0 = fixture_http_server.captured_requests[0]
-    assert req0[0] == "POST"
-    data = json.loads(req0[1])
+    req0 = fixture_http_server.requests[0]
+    assert req0.method == "POST"
+    data = req0.get_json()
     assert data == expected_slack_requests[0]

--- a/tests/test_phpbb2slack.py
+++ b/tests/test_phpbb2slack.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Unit tests for phpbb2slack.py."""
 import io
-import json
 import logging
 import os
 import sys
@@ -156,7 +155,7 @@ def test_main_ideal(
         200,
         {"Content-Type": "application/json"},
     )
-    fixture_http_server.capture_requests = True
+    fixture_http_server.store_request_data = True
 
     cache = CachedData()
     source1 = cache.get_source_by_url(rss_url)
@@ -232,9 +231,9 @@ def test_main_ideal(
     # Note: this is just a shallow check, but it's better than nothing.
     assert len(fixture_http_server.requests) == 1
 
-    req0 = fixture_http_server.captured_requests[0]
-    assert req0[0] == "POST"
-    data = json.loads(req0[1])
+    req0 = fixture_http_server.requests[0]
+    assert req0.method == "POST"
+    data = req0.get_json()
     assert data == expected_slack_requests[0]
 
 
@@ -263,7 +262,7 @@ def test_main_cache_hit(
         500,
         {"Content-Type": "application/json"},
     )
-    fixture_http_server.capture_requests = True
+    fixture_http_server.store_request_data = True
 
     cache = CachedData()
     source1 = cache.get_source_by_url(rss_url)

--- a/tests/test_rss2slack.py
+++ b/tests/test_rss2slack.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Unit tests for rss2slack.py."""
 import io
-import json
 import logging
 import os
 import sys
@@ -150,7 +149,7 @@ def test_main_ideal(
         200,
         {"Content-Type": "application/json"},
     )
-    fixture_http_server.capture_requests = True
+    fixture_http_server.store_request_data = True
 
     cache = CachedData()
     source1 = cache.get_source_by_url(rss_url)
@@ -224,14 +223,14 @@ def test_main_ideal(
     # Note: this is just a shallow check, but it's better than nothing.
     assert len(fixture_http_server.requests) == 2
 
-    req0 = fixture_http_server.captured_requests[0]
-    assert req0[0] == "POST"
-    data = json.loads(req0[1])
+    req0 = fixture_http_server.requests[0]
+    assert req0.method == "POST"
+    data = req0.get_json()
     assert data == expected_slack_requests[0]
 
-    req1 = fixture_http_server.captured_requests[1]
-    assert req1[0] == "POST"
-    data = json.loads(req1[1])
+    req1 = fixture_http_server.requests[1]
+    assert req1.method == "POST"
+    data = req1.get_json()
     assert data == expected_slack_requests[1]
 
 
@@ -262,7 +261,6 @@ def test_main_cache_hit(
         500,
         {"Content-Type": "application/json"},
     )
-    fixture_http_server.capture_requests = True
 
     cache = CachedData()
     source1 = cache.get_source_by_url(rss_url)


### PR DESCRIPTION
pytest-localserver is capable of storing request data now, therefore there
is no need for MyContentServer anymore.