### PR TITLE
Set timeout on pipe open

### DIFF
--- a/lib/config_options.py
+++ b/lib/config_options.py
@@ -7,3 +7,5 @@ workarounds are needed what so ever.
 CACHE_EXPIRATION = 86400  # seconds
 DATA_SOURCE_EXPIRATION = 30 * 86400  # seconds
 HTTP_TIMEOUT = 30  # seconds
+PIPE_OPEN_TIMEOUT = 60  # seconds
+PIPE_WRITE_TIMEOUT = 5  # seconds


### PR DESCRIPTION
I cannot explain intricacies, however I've noticed that rss2irc got indefinitely stuck when iibot got into some ~funky~ unexpected state. Based on contents of stack and strace I came to conclusion this was when open() was called on pipe(because iibot uses named pipes for input). Therefore, let's add timeout around open() call and we shall see.